### PR TITLE
[dev] (setup) Add 'numpy' package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -264,7 +264,8 @@ zomato_custom = ['statsmodels~=0.9.0',
                  'overrides',
                  'sqlparser',
                  'werkzeug==0.16.1',
-                 'jsonnet']
+                 'jsonnet'
+                 'tabulate']
 
 all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant + druid + pinot \
           + cassandra + mongo

--- a/setup.py
+++ b/setup.py
@@ -265,7 +265,7 @@ zomato_custom = ['statsmodels~=0.9.0',
                  'sqlparser',
                  'werkzeug==0.16.1',
                  'jsonnet'
-                 'tabulate']
+                 'numpy']
 
 all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant + druid + pinot \
           + cassandra + mongo


### PR DESCRIPTION
### Description
- add `numpy` for some statistical computations in an adhoc script
- had added [`tabulate` package](https://pypi.org/project/tabulate/) for formatting output messages in logs earlier; only to later discover that it was [already present](https://github.com/Zomato/airflow/blob/zmaster/setup.py#L373)